### PR TITLE
Fix Manual Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cp -r ./decompilers/d2d_ida/* /path/to/ida/plugins/
 If you also need to install the gdb side of things, use the line below: 
 ```bash
 pip3 install . && \
-cp decomp2dbg.py ~/.decomp2dbg.py && echo "source ~/.decomp2gef.py" >> ~/.gdbinit
+cp decomp2dbg.py ~/.decomp2dbg.py && echo "source ~/.decomp2dbg.py" >> ~/.gdbinit
 ```
 
 ## Usage 


### PR DESCRIPTION
Manual install instructions add `source ~/.decomp2gef.py` instead of `~/.decomp2gdb.py`.