### PR TITLE
Register Variable Support

### DIFF
--- a/decomp2dbg/clients/gdb/gdb_client.py
+++ b/decomp2dbg/clients/gdb/gdb_client.py
@@ -242,9 +242,7 @@ class GDBClient:
     #
 
     def on_decompiler_connected(self, decompiler_name):
-        if not self.text_segment_base_addr:
-            self.text_segment_base_addr = find_text_segment_base_addr(is_remote=is_remote_debug())
-
+        self.text_segment_base_addr = find_text_segment_base_addr(is_remote=is_remote_debug())
         self.dec_client.update_symbols()
         self.register_decompiler_context_pane(decompiler_name)
 

--- a/decomp2dbg/clients/gdb/gef_client.py
+++ b/decomp2dbg/clients/gdb/gef_client.py
@@ -12,5 +12,4 @@ class GEFClient(GDBClient):
         self.ctx_pane_registrar("decompilation", self.dec_pane.display_pane, self.dec_pane.title)
 
     def deregister_decompiler_context_pane(self, decompiler_name):
-        print("deregister called!")
         self.gef_config["context.layout"] = self.gef_config["context.layout"].replace(" decompilation", "")

--- a/decompilers/d2d_angr/server.py
+++ b/decompilers/d2d_angr/server.py
@@ -102,7 +102,7 @@ class AngrDecompilerServer:
 
         """
         resp = {
-            "args": {},
+            "reg_vars": {},
             "stack_vars": {}
         }
 

--- a/decompilers/d2d_binja/server.py
+++ b/decompilers/d2d_binja/server.py
@@ -2,6 +2,7 @@ from xmlrpc.server import SimpleXMLRPCServer, SimpleXMLRPCRequestHandler
 
 from binaryninja import SymbolType, EntryRegisterValue
 from binaryninja.binaryview import BinaryDataNotification
+import binaryninja
 
 #
 # Binja Hooks
@@ -92,7 +93,7 @@ class BinjaDecompilerServer:
 
         """
         resp = {
-            "args": {},
+            "reg_vars": {},
             "stack_vars": {}
         }
 
@@ -121,15 +122,18 @@ class BinjaDecompilerServer:
                 "type": str(stack_var.type)
             }
 
-        # get args
-        func_args = {}
-        for idx, param in enumerate(func.function_type.parameters):
-            func_args[str(idx)] = {
-                "name": param.name,
-                "type": str(param.type)
+        # get reg vars
+        reg_vars = {}
+        for var in func.vars:
+            if var.source_type != binaryninja.VariableSourceType.RegisterVariableSourceType or not var.name:
+                continue
+
+            reg_vars[var.name] = {
+                "reg_name": self.bv.arch.get_reg_name(var.storage),
+                "type": str(var.type)
             }
 
-        resp["args"] = func_args
+        resp["reg_vars"] = reg_vars
         resp["stack_vars"] = stack_vars
 
         return resp

--- a/decompilers/d2d_ida/d2d_ida/server.py
+++ b/decompilers/d2d_ida/d2d_ida/server.py
@@ -142,9 +142,8 @@ class IDADecompilerServer:
     @execute_read
     def function_data(self, addr):
         resp = {
-            "args": None,
             "stack_vars": None,
-            "reg_vars": None,
+            "reg_vars": None
         }
 
         # get the function

--- a/decompilers/d2d_ida/d2d_ida/server.py
+++ b/decompilers/d2d_ida/d2d_ida/server.py
@@ -230,6 +230,9 @@ class IDADecompilerServer:
         known_segs = [".data", ".bss"]
         for seg_name in known_segs:
             seg = idaapi.get_segm_by_name(seg_name)
+            if not seg:
+                continue
+
             for seg_ea in range(seg.start_ea, seg.end_ea):
                 xrefs = idautils.XrefsTo(seg_ea)
                 try:

--- a/decompilers/d2d_ida/d2d_ida/server.py
+++ b/decompilers/d2d_ida/d2d_ida/server.py
@@ -160,7 +160,6 @@ class IDADecompilerServer:
             return resp
 
         # get var info
-        frame = idaapi.get_frame(func_addr)
         stack_vars = {}
         reg_vars = {}
 
@@ -170,11 +169,7 @@ class IDADecompilerServer:
 
             # stack variables
             if var.is_stk_var():
-                offset = cfunc.mba.stacksize \
-                         - var.location.stkoff() \
-                         + idaapi.get_member_size(frame.get_member(frame.memqty - 1))
-
-                print(var.name, hex(offset))
+                offset = cfunc.mba.stacksize - var.location.stkoff()
                 stack_vars[str(offset)] = {
                     "name": var.name,
                     "type": str(var.type())
@@ -191,36 +186,8 @@ class IDADecompilerServer:
                 }
                 pass
 
-
-        # stack var info
-        frame = idaapi.get_frame(func_addr)
-        stack_vars = {}
-        for var in cfunc.lvars:
-            if not var.name or not var.location.in_stack:
-                continue
-
-            offset = cfunc.mba.stacksize \
-                - var.location.stkoff() \
-                + idaapi.get_member_size(frame.get_member(frame.memqty - 1))
-
-            stack_vars[str(offset)] = {
-                "name": var.name,
-                "type": str(var.type())
-            }
-
-        # function arguments info
-        func_args = {}
-        for arg, idx in zip(cfunc.arguments, cfunc.argidx):
-            if not arg.name:
-                continue
-
-            func_args[str(idx)] = {
-                "name": arg.name,
-                "type": str(arg.type())
-            }
-
-        resp["args"] = func_args
         resp["stack_vars"] = stack_vars
+        resp["reg_vars"] = reg_vars
 
         return resp
 

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ install_ida() {
         return
     else
         echo "INSTALLING: IDA plugin WITH linking to ${IDA_PATH}"
-        ln -s "${LOC}/decompilers/d2d_ida/decomp2dbg_ida.py" "$IDA_PATH" && \
+        ln -s "${LOC}/decompilers/d2d_ida/d2d_ida.py" "$IDA_PATH" && \
         ln -s "${LOC}/decompilers/d2d_ida/d2d_ida/" "$IDA_PATH" && \
         echo "IDA install was successful!" && \
         return


### PR DESCRIPTION
- we can now supper _every_ variable shown in a decompiler (including the ones assigned to a variable)
- functions args are being deprecated in favor of setting them through either register vars or stack vars
- refactored some janky type setting code

Closes #38 