### PR TITLE
unshorten print command which could potentially break if p is aliased

### DIFF
--- a/decomp2dbg/clients/gdb/utils.py
+++ b/decomp2dbg/clients/gdb/utils.py
@@ -105,7 +105,7 @@ def is_32bit():
 
 def pc():
     try:
-        pc_ = int(gdb.execute("p/x $pc",to_string=True).split(" ")[-1], 16)
+        pc_ = int(gdb.execute("print/x $pc",to_string=True).split(" ")[-1], 16)
     except Exception:
         pc_ = None
 


### PR DESCRIPTION
I reckon it's better that we stick to the full "print" command instead of using "p" which is commonly aliased to other commands  (i.e. if you have gef-extras installed) - which would cause context printing to break.

_screenshot extracted from [gef-extras/windbg.py](https://github.com/hugsy/gef-extras/blob/dev/scripts/windbg.py#L422)_
![Screenshot_20230109_232809](https://user-images.githubusercontent.com/76640319/211344770-f45ba56e-f258-4213-8ab8-fd8544900c7b.png)