### PR TITLE
Added pwndbg marshaling fix

### DIFF
--- a/decomp2dbg/clients/gdb/pwndbg_client.py
+++ b/decomp2dbg/clients/gdb/pwndbg_client.py
@@ -5,6 +5,7 @@ import pwndbg
 from .gdb_client import GDBClient
 from .decompiler_pane import DecompilerPane
 from ...utils import *
+import xmlrpc.client
 
 
 class PwndbgDecompilerPane(DecompilerPane):
@@ -74,6 +75,11 @@ class PwndbgClient(GDBClient):
     def __init__(self):
         super(PwndbgClient, self).__init__()
         self.dec_pane = PwndbgDecompilerPane(self.dec_client)
+
+        # if we are connected to ghidra
+        if not isinstance(self.dec_client.server, xmlrpc.client.ServerProxy):
+            # reset the type handlers pwndbg adds
+            xmlrpc.client.Marshaller.dispatch[type(0)] = xmlrpc.client.Marshaller.dump_long
 
     def register_decompiler_context_pane(self, decompiler_name):
         pwndbg.commands.context.context_sections["g"] = self.dec_pane.context_gdecompiler


### PR DESCRIPTION
Fixes an issue with pwndbg and ghidra by removing a type handler in the xmlrpc marshaller.

Without this fix, getting decompilation fails because the ghidra xmlparser does not understand the type **i8** that is used when decompile(rebased_pc) is called. An **i8** is being used instead of an **int** because of a handler pwndbg adds to support connections with ida ([1](https://github.com/pwndbg/pwndbg/blob/00425e8ccb88c95d46946d69ec009e2c6d9df94a/pwndbg/ida.py#L43))

This is fixed by checking if the server is connected to ghidra and then resetting the int type handler for the marshaller. 