### PR TITLE
Fix Ghidra Plugin for Ghidra 10.3.2

### DIFF
--- a/.github/workflows/ghidra-build.yml
+++ b/.github/workflows/ghidra-build.yml
@@ -1,9 +1,9 @@
 name: Ghidra Extension Build
 
 env:
-  ghidra-url: https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.3_build/ghidra_10.3_PUBLIC_20230510.zip
-  ghidra-zip-filename: ghidra_10.3_PUBLIC.zip
-  ghidra-directory: ghidra_10.3_PUBLIC
+  ghidra-url: https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.3.2_build/ghidra_10.3.2_PUBLIC_20230711.zip
+  ghidra-zip-filename: ghidra_10.3.2_PUBLIC.zip
+  ghidra-directory: ghidra_10.3.2_PUBLIC
 
 on:
   workflow_run:

--- a/decomp2dbg/__init__.py
+++ b/decomp2dbg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.5.1"
+__version__ = "3.5.2"
 
 try:
     from .clients.client import DecompilerClient

--- a/decompilers/d2d_ghidra/src/main/java/decomp2dbg/D2DGhidraServerAPI.java
+++ b/decompilers/d2d_ghidra/src/main/java/decomp2dbg/D2DGhidraServerAPI.java
@@ -8,6 +8,7 @@ import ghidra.app.decompiler.ClangLine;
 import ghidra.app.decompiler.PrettyPrinter;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.symbol.Symbol;
+import ghidra.program.model.symbol.IdentityNameTransformer;
 import ghidra.program.model.symbol.SymbolType;
 import ghidra.util.Msg;
 
@@ -64,7 +65,7 @@ public class D2DGhidraServerAPI {
 	    var decLines = dec.getDecompiledFunction().getC().split("\n");
 	    resp.put("decompilation", decLines);
 		
-		PrettyPrinter pp = new PrettyPrinter(func, dec.getCCodeMarkup());
+		PrettyPrinter pp = new PrettyPrinter(func, dec.getCCodeMarkup(), new IdentityNameTransformer());
 	    ArrayList<ClangLine> lines = pp.getLines();
 	    
 	    // locate the decompilation line

--- a/decompilers/d2d_ghidra/src/main/java/decomp2dbg/D2DGhidraServerAPI.java
+++ b/decompilers/d2d_ghidra/src/main/java/decomp2dbg/D2DGhidraServerAPI.java
@@ -8,7 +8,6 @@ import ghidra.app.decompiler.ClangLine;
 import ghidra.app.decompiler.PrettyPrinter;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.symbol.Symbol;
-import ghidra.program.model.symbol.IdentityNameTransformer;
 import ghidra.program.model.symbol.SymbolType;
 import ghidra.util.Msg;
 
@@ -65,7 +64,7 @@ public class D2DGhidraServerAPI {
 	    var decLines = dec.getDecompiledFunction().getC().split("\n");
 	    resp.put("decompilation", decLines);
 		
-		PrettyPrinter pp = new PrettyPrinter(func, dec.getCCodeMarkup(), new IdentityNameTransformer());
+		PrettyPrinter pp = new PrettyPrinter(func, dec.getCCodeMarkup(), null);
 	    ArrayList<ClangLine> lines = pp.getLines();
 	    
 	    // locate the decompilation line


### PR DESCRIPTION
The ghidra plugin is currently broken for ghidra 10.3.2 (and 10.3.1, too, although this might be a different problem). This fixes the problem by providing a correct third argument for `PrettyPrinter`