### PR TITLE
Fix Python Error: Unable to find the text segment base addr

### DIFF
--- a/decomp2dbg/clients/gdb/utils.py
+++ b/decomp2dbg/clients/gdb/utils.py
@@ -57,7 +57,7 @@ def vmmap_base_addrs():
     for mapping in mappings:
         try:
             addr = int(re.findall(r"0x[0-9a-fA-F]+", mapping)[0], 16)
-            path = mapping.split(" ")[-1]
+            path = re.findall(r"(/.*)", mappings)[0].strip()
         except IndexError:
             continue
 


### PR DESCRIPTION
Closes #69 and #79 

PR for issue
Python Exception <class 'Exception'>: Unable to find the text segment base addr, please report this!