### PR TITLE
Checked for overflow error and added error msg to setup

### DIFF
--- a/decomp2dbg/__init__.py
+++ b/decomp2dbg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.8.1"
+__version__ = "3.8.2"
 
 try:
     from .clients.client import DecompilerClient

--- a/decomp2dbg/clients/gdb/decompiler_pane.py
+++ b/decomp2dbg/clients/gdb/decompiler_pane.py
@@ -30,6 +30,14 @@ class DecompilerPane:
         # decompile the current pc location
         try:
             resp = self.decompiler.decompile(rebased_pc)
+        except OverflowError as e:
+            warn(
+                f"Decompiler failed to get a response from decompiler on "
+                f"{hex(rebased_pc) if isinstance(
+                    rebased_pc, int) else rebased_pc} with: {e}"
+                f", are you in a library function?"
+            )
+            return False
         except Exception as e:
             warn(f"Decompiler failed to get a response from decompiler on "
                  f"{hex(rebased_pc) if isinstance(rebased_pc,int) else rebased_pc} with: {e}")

--- a/setup.py
+++ b/setup.py
@@ -19,27 +19,31 @@ def _copy_decomp_plugins():
     local_d2d = Path("d2d.py").absolute()
 
     # clean the install location of symlink or folder
-    shutil.rmtree(pip_e_plugins, ignore_errors=True)
+    try:
+        shutil.rmtree(pip_e_plugins, ignore_errors=True)
+    except Exception as e:
+        print(f"Exception occurred while removing {pip_e_plugins}: {e}")
+
     try:
         os.unlink(pip_e_plugins)
         os.unlink(decomp2dbg_loc.joinpath(local_d2d.name))
-    except:
-        pass
+    except Exception as e:
+        print(f"Exception occurred during cleaning of install location: {e}")
 
     # first attempt a symlink, if it works, exit early
     try:
         os.symlink(local_plugins, pip_e_plugins, target_is_directory=True)
         os.symlink(local_d2d, decomp2dbg_loc.joinpath(local_d2d.name))
         return
-    except:
-        pass
+    except Exception as e:
+        print(f"Exception occured during symlinking process: {e}")
 
     # copy if symlinking is not available on target system
     try:
         shutil.copytree("decompilers", "decomp2dbg/decompilers")
         shutil.copy("d2d.py", "decomp2dbg/d2d.py")
-    except:
-        pass
+    except Exception as e:
+        print(f"Exception occurred during copying process: {e}")
 
 class build(st_build):
     def run(self, *args):


### PR DESCRIPTION
Just adding an extra bit of information when you tried to attach the debugger while in something like a library function.

The rest we can take or leave, I just didn't want to have a `pass` on a potential error during local install.