### PR TITLE
#54 add elf info method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build/*
 *.gdb_history
 decomp2dbg/decompilers
 decomp2dbg/d2d.py
+decompilers/*/.gradle/
+decompilers/*/build/
+decompilers/*/dist/

--- a/decompilers/d2d_ghidra/src/main/java/decomp2dbg/D2DPlugin.java
+++ b/decompilers/d2d_ghidra/src/main/java/decomp2dbg/D2DPlugin.java
@@ -57,6 +57,7 @@ public class D2DPlugin extends ProgramPlugin implements DomainObjectListener {
 	public Map<String, Object> typeAliasCache;
 	public Map<String, Object> unionCache;
 	public Map<String, Object> enumCache;
+	public Map<String, Object> elfInfoCache;
 	
 	public D2DPlugin(PluginTool tool) {
 		super(tool);
@@ -74,6 +75,7 @@ public class D2DPlugin extends ProgramPlugin implements DomainObjectListener {
 		typeAliasCache = new HashMap<>();
 		unionCache = new HashMap<>();
 		enumCache = new HashMap<>();
+		elfInfoCache = new HashMap<>();
 	}
 	
 	@Override


### PR DESCRIPTION
This method provides info required to build ELF file accepted by gdb:
  - machine id
  - endianness
  - bit size

It also provides:
  - image base offset to rebase symbols to their original offsets
  - ELF flags (not mandatory)
  - program name