### PR TITLE
Fix failed section removal in objcopy

### DIFF
--- a/decomp2dbg/__init__.py
+++ b/decomp2dbg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.9.3"
+__version__ = "3.9.4"
 
 try:
     from .clients.client import DecompilerClient

--- a/decomp2dbg/clients/gdb/symbol_mapper.py
+++ b/decomp2dbg/clients/gdb/symbol_mapper.py
@@ -163,8 +163,8 @@ class SymbolMapper:
 
         required_sections = [".text", ".interp", ".rela.dyn", ".dynamic", ".bss"]
         for s in elf.iter_sections():
-            # keep some required sections
-            if s.name in required_sections:
+            # keep some required sections, skip broken ones
+            if not s.name or s.name in required_sections:
                 continue
             os.system(f"{self._objcopy} --remove-section={s.name} {fname}.debug 2>/dev/null")
 

--- a/decomp2dbg/clients/gdb/symbol_mapper.py
+++ b/decomp2dbg/clients/gdb/symbol_mapper.py
@@ -162,11 +162,13 @@ class SymbolMapper:
         elf = ELFFile(open(f'{fname}.debug', 'rb'))
 
         required_sections = [".text", ".interp", ".rela.dyn", ".dynamic", ".bss"]
-        for s in elf.iter_sections():
+        all_sections = [s.name for s in elf.iter_sections()]
+        for s_name in all_sections:
             # keep some required sections, skip broken ones
-            if not s.name or s.name in required_sections:
+            if not s_name or s_name in required_sections:
                 continue
-            os.system(f"{self._objcopy} --remove-section={s.name} {fname}.debug 2>/dev/null")
+
+            os.system(f"{self._objcopy} --remove-section={s_name} {fname}.debug 2>/dev/null")
 
         # cache the small object file for use
         self._elf_cache["fname"] = fname + ".debug"


### PR DESCRIPTION
Closes #99. The root cause was a corrupted section header, which seems to trigger only when connecting over a remote connection. 

However, after fixing this bug I triggered a new one:
```
Python Exception <class 'NameError'>: name 'add_context_layout_mapping' is not defined
Error occurred in Python: name 'add_context_layout_mapping' is not defined
```

Which is a GEF bug. I've fixed it in https://github.com/hugsy/gef/pull/1124, so after that lands, an updated GEF should work again on the case described in #99. 