### PR TITLE
Replaces deprecated functions in IDA 9.0

### DIFF
--- a/decompilers/d2d_ida/d2d_ida/plugin.py
+++ b/decompilers/d2d_ida/d2d_ida/plugin.py
@@ -13,7 +13,9 @@ import threading
 from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QMessageBox, QGridLayout
 
-import idaapi, ida_idp, ida_struct, idc, ida_enum
+import idaapi, ida_idp, idc
+
+IDA_VERSION = idaapi.get_kernel_version()
 
 from .server import IDADecompilerServer
 
@@ -29,8 +31,13 @@ class IDBHooks(ida_idp.IDB_Hooks):
         ida_idp.IDB_Hooks.__init__(self)
 
     def renamed(self, ea, new_name, local_name):
-        if ida_struct.is_member_id(ea) or ida_struct.get_struc(ea) or ida_enum.get_enum_name(ea):
-            return 0
+        if IDA_VERSION == "9.0":
+            if idc.is_member_id(ea) or idc.get_struc(ea) or idc.get_enum_name(ea):
+                return 0
+        else:
+            import ida_struct, ida_enum
+            if ida_struct.is_member_id(ea) or ida_struct.get_struc(ea) or ida_enum.get_enum_name(ea):
+                return 0
 
         # renaming a function header
         ida_func = idaapi.get_func(ea)


### PR DESCRIPTION
Replaces the following deprecated functions whilst also maintaining backward compatibility for older versions

| IDA 8.4 | IDA 9.0|
| - | - |
| `ida_struct.get_struc` | `idc.get_struc` |
| `ida_enum.get_enum_name` | `idc.get_enum_name` |
| `ida_struct.is_member_id` | `idc.is_member_id` |

More information can be found in these 2 links
- [ida_enum changes](https://docs.hex-rays.com/pre-release/developer-guide/idapython/idapython-porting-guide-ida-9#ida_enum)
- [ida_struct changes](https://docs.hex-rays.com/pre-release/developer-guide/idapython/idapython-porting-guide-ida-9#ida_struct)