### PR TITLE
Fix returned path in binary ninja

### DIFF
--- a/decompilers/d2d_binja/server.py
+++ b/decompilers/d2d_binja/server.py
@@ -211,7 +211,7 @@ class BinjaDecompilerServer:
         """
         Get the filesystem path of the binary being decompiled.
         """
-        return self.bv.file.filename
+        return self.bv.file.original_filename
 
     def versions(self) -> dict[str, str]:
         """


### PR DESCRIPTION
Before, it sometimes returned the path of the database, but this endpoinds expects the actual binary.