### PR TITLE
Fix version to match releases

### DIFF
--- a/decomp2dbg/__init__.py
+++ b/decomp2dbg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.12.3"
+__version__ = "3.13.3"
 
 try:
     from .clients.client import DecompilerClient


### PR DESCRIPTION
This thing says 3.12.3, but this version hasn't been released and instead https://github.com/mahaloz/decomp2dbg/releases/tag/v3.13.3 has been released.

This tripped up my ghidra plugin installation code which does this
```python
    download_url: str = f"https://github.com/mahaloz/decomp2dbg/releases/download/v{d2d_required_version_str}/d2d-ghidra-plugin.zip"
    download_dest: Path = d2d_cache_dir / "d2d-ghidra-plugin.zip"
```