### PR TITLE
Fix compatibility with eg: riscv64 by making wheel universal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,14 +60,4 @@ cmdclass = {
     "build": build,
     "develop": develop,
 }
-
-if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
-    sys.argv.append('--plat-name')
-    name = get_platform()
-    if 'linux' in name:
-        sys.argv.append('manylinux2014_' + platform.machine())
-    else:
-        # https://www.python.org/dev/peps/pep-0425/
-        sys.argv.append(name.replace('.', '_').replace('-', '_'))
-
 setup(cmdclass=cmdclass)


### PR DESCRIPTION
Currently, installing decomp2dbg fails on non-standard architectures 
(e.g., riscv64) because the wheel is incorrectly marked as platform-specific. The error looks like this:

```
  × Failed to download and build `decomp2dbg==3.14.0`
  ╰─▶ The built wheel `decomp2dbg-3.14.0-py3-none-manylinux2014_riscv64.whl` 
     is not compatible with the current Python 3.13 on manylinux riscv64
```

This happens because setup.py forces a platform-specific wheel tag 
(`manylinux2014_<arch>`), even though decomp2dbg is implemented purely in Python 
and contains no compiled extensions.

This PR removes the forced platform tag, allowing setuptools to generate a universal 
wheel (`py3-none-any.whl`).
